### PR TITLE
Offer opt-out for redundant build before performing test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,6 +48,7 @@ workflows:
         - simulator_device: iPhone 6
         # - simulator_device: Apple TV 1080p
         # - simulator_platform: tvOS Simulator
+        - should_build_before_test: "yes"
         - xcodebuild_test_options: -verbose
     - script:
         title: Output test

--- a/go/src/github.com/bitrise-io/xcode-test/logutil/logutil.go
+++ b/go/src/github.com/bitrise-io/xcode-test/logutil/logutil.go
@@ -56,13 +56,15 @@ func LogConfigs(
 	outputTool,
 	exportUITestArtifactsStr,
 	testOptions,
-	singleBuild string) {
+	singleBuild,
+	shouldBuildBeforeTest string) {
 	LogInfo("Configs:")
 	LogDetails("* project_path: %s", projectPath)
 	LogDetails("* scheme: %s", scheme)
 	LogDetails("* is_clean_build: %v", isCleanBuild)
 	LogDetails("* xcodebuild_test_options: %s", testOptions)
 	LogDetails("* single_build: %s", singleBuild)
+	LogDetails("* should_build_before_test: %s", shouldBuildBeforeTest)
 	fmt.Println()
 	LogDetails("* simulator_platform: %s", simulatorPlatform)
 	LogDetails("* simulator_device: %s", simulatorDevice)

--- a/go/src/github.com/bitrise-io/xcode-test/models/models.go
+++ b/go/src/github.com/bitrise-io/xcode-test/models/models.go
@@ -20,6 +20,7 @@ type XcodeBuildTestParamsModel struct {
 	BuildParams XcodeBuildParamsModel
 
 	CleanBuild           bool
+	BuildBeforeTest      bool
 	GenerateCodeCoverage bool
 	AdditionalOptions    string
 }

--- a/step.yml
+++ b/step.yml
@@ -179,7 +179,15 @@ inputs:
       - "false"
   - should_build_before_test: "yes"
     opts:
-      title: "Explicitly perform a build before testing? (Should be yes when experiencing unexplainable timeouts during testing)"
+      title: "(Experimental) Explicitly perform a build before testing?"
+      description: |-
+        Previous Xcode versions and configurations may throw the error `iPhoneSimulator: Timed out waiting 120 seconds for simulator to boot, current state is 1.`
+        when the compilation before performing the tests takes too long.
+
+        This is fixed by running `xcodebuild OPTIONS build test OPTIONS` instead of `xcodebuild OPTIONS test OPTIONS`.
+        Calling an explicit build before the test results in the code being compiled twice, thus creating an overhead.
+
+        Unless you are sure that your configuration is not prone to this error, it is recommended to leave this option turned on.
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -177,6 +177,13 @@ inputs:
       value_options:
       - "true"
       - "false"
+  - should_build_before_test: "yes"
+    opts:
+      title: "Explicitly perform a build before testing? (Should be yes when experiencing unexplainable timeouts during testing)"
+      value_options:
+        - "yes"
+        - "no"
+      is_required: true
 outputs:
 - BITRISE_XCODE_TEST_RESULT:
   opts:


### PR DESCRIPTION
closes #55 

- [ ] finalize wording
- [ ] still has to be properly tested

**possible further actions**
- [ ] test which xcode version runs properly
- [ ] test sample project for timeout bug: https://openradar.appspot.com/22413115
- [ ] inspect possible fix for timeout: [launching simulator before calling xcodebuild](https://discuss.circleci.com/t/iphonesimulator-timed-out-waiting-120-seconds-for-simulator-to-boot-current-state-is-1/244/6)