### PR TITLE
export .xcresult's path at the end of the step 

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -259,8 +259,15 @@ workflows:
               echo "No BITRISE_XCODE_RAW_TEST_RESULT_TEXT_PATH file generated!"
               exit 1
             fi
+
+            if [ ! -d $BITRISE_XCRESULT_PATH ]; then
+                echo "Xcode results not found in $BITRISE_XCRESULT_PATH"
+                exit 1
+            fi
+
             echo "BITRISE_XCODE_RAW_TEST_RESULT_TEXT_PATH: ${BITRISE_XCODE_RAW_TEST_RESULT_TEXT_PATH}"
             echo "BITRISE_XCODE_TEST_ATTACHMENTS_PATH: ${BITRISE_XCODE_TEST_ATTACHMENTS_PATH}"
+            echo "BITRISE_XCRESULT_PATH: $BITRISE_XCRESULT_PATH"
     - change-workdir:
         title: Switch back to work dir at the start.
         inputs:

--- a/main.go
+++ b/main.go
@@ -646,4 +646,8 @@ that will attach the file to your build as an artifact!`, logPth)
 	if err := cmd.ExportEnvironmentWithEnvman("BITRISE_XCODE_TEST_RESULT", "succeeded"); err != nil {
 		log.Warnf("Failed to export: BITRISE_XCODE_TEST_RESULT, error: %s", err)
 	}
+
+	if err := cmd.ExportEnvironmentWithEnvman("BITRISE_XCRESULT_PATH", buildTestParams.TestOutputDir); err != nil {
+		log.Warnf("Failed to export: BITRISE_XCRESULT_PATH, error: %s", err)
+	}
 }

--- a/step.yml
+++ b/step.yml
@@ -251,6 +251,11 @@ outputs:
 
       If the compilation fails this log will contain the compilation output,
       if the tests can be started it'll only include the test output.
+- BITRISE_XCRESULT_PATH:
+  opts:
+    title: The path of the generated `.xcresult`
+    description: |-
+      The path of the generated `.xcresult`.
 - BITRISE_XCODE_TEST_ATTACHMENTS_PATH:
   opts:
     title: The full, test attachments zip path


### PR DESCRIPTION
We use a dynamically generated temp dir for the -resultBundlePath, this why we need to export it.